### PR TITLE
Use homeassistant.const CONF_HOST and CONF_PORT in minio

### DIFF
--- a/homeassistant/components/minio/__init__.py
+++ b/homeassistant/components/minio/__init__.py
@@ -7,7 +7,12 @@ import threading
 
 import voluptuous as vol
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -17,10 +22,6 @@ from .minio_helper import MinioEventThread, create_minio_client
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "minio"
-# pylint: disable-next=home-assistant-duplicate-const
-CONF_HOST = "host"
-# pylint: disable-next=home-assistant-duplicate-const
-CONF_PORT = "port"
 CONF_ACCESS_KEY = "access_key"
 CONF_SECRET_KEY = "secret_key"
 CONF_SECURE = "secure"

--- a/tests/components/minio/test_minio.py
+++ b/tests/components/minio/test_minio.py
@@ -8,15 +8,14 @@ import pytest
 
 from homeassistant.components.minio import (
     CONF_ACCESS_KEY,
-    CONF_HOST,
     CONF_LISTEN,
     CONF_LISTEN_BUCKET,
-    CONF_PORT,
     CONF_SECRET_KEY,
     CONF_SECURE,
     DOMAIN,
     QueueListener,
 )
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change. The constant values are byte-identical (`"host"` / `"port"`), so configuration and runtime behavior are unchanged.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `minio` integration defined `CONF_HOST = "host"` and `CONF_PORT = "port"` locally, duplicating constants that already exist in `homeassistant.const`. These were suppressed with two `# pylint: disable-next=home-assistant-duplicate-const` comments.

This PR:

- Removes the local `CONF_HOST` / `CONF_PORT` definitions in `homeassistant/components/minio/__init__.py` and imports them from `homeassistant.const` instead.
- Drops the now-unnecessary `home-assistant-duplicate-const` pylint disable comments.
- Updates `tests/components/minio/test_minio.py` to import `CONF_HOST` / `CONF_PORT` from `homeassistant.const`.

`homeassistant.const.CONF_HOST` and `CONF_PORT` resolve to the exact same string values, so there is no functional change.

Verification: `ruff check` and `ruff format --check` pass (pinned 0.15.13). The pytest suite could not be executed in this environment because the project requires Python ≥ 3.14.2, which is not available/installable here; the change is behavior-preserving since the constant values are identical.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#171289 (part of epic home-assistant/core#69)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: `https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure`

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_018Jyy9xwjTS7QykKGGjf6pg)_